### PR TITLE
Update Prompt for Geolocation Format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# This is just an example .env file.
+# Copy to .env and modify with your configuration values.
+
+# Once you add your API key below, make sure to not share it with anyone! The API key should remain private.
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# LangChain API Quickstart - Python/Flask concept api
+# wander-api
+
+This is the backend API for the [WanderGuide](https://github.com/DaveedBalcher/WanderGuide/) iOS app that allows users to generate a customized walking tour for a particular city or town center.
+
+## LangChain API - Python concept api
 
 This is an example walking tour generator api using [LangChain](https://python.langchain.com/docs/get_started/introduction.html), built around the OpenAI API [quickstart tutorial](https://beta.openai.com/docs/quickstart). It uses the [FastAPI](https://fastapi.tiangolo.com/) web framework. Check out the tutorial or follow the instructions below to get set up.
 
@@ -11,7 +15,7 @@ This is an example walking tour generator api using [LangChain](https://python.l
 3. Navigate into the project directory:
 
    ```bash
-   $ cd langchain
+   $ cd wander-api
    ```
 
 4. Create a new virtual environment:
@@ -42,4 +46,3 @@ This is an example walking tour generator api using [LangChain](https://python.l
    ```
 
 You should now be able to access the api at [http://localhost:8000](http://localhost:8000)!
-For the full context behind the OpenAI API example app, check out the [tutorial](https://beta.openai.com/docs/quickstart).

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ async def tour(
     system_prompt = SystemMessagePromptTemplate.from_template(chat_prompt)
 
     human_template = f"""
-        I am interested in {interests}. I have {duration} hours and would like to walk no more than {distance} miles. My budget is {budget} dollars. I want to start in the {start_time}. Please create a suggested walking tour in {location} based on the previous parameters. I would like the results formatted as valid json with each location having the following fields: location_name, category, story, suggested_visit_duration, and geolocation. The story should be fun and detailed.
+        I am interested in {interests}. I have {duration} hours and would like to walk no more than {distance} miles. My budget is {budget} dollars. I want to start in the {start_time}. Please create a suggested walking tour in {location} based on the previous parameters. I would like the results formatted as valid json with each location having the following properties: location_name, category, story, suggested_visit_duration, and geolocation. geolocation should be an object with latitude and longitude properties. Latitude and Longitude should be in number format only. The story should be fun and detailed.
         """
     print("HUMAN ASK", human_template)
     human_prompt = HumanMessagePromptTemplate.from_template(human_template)

--- a/main.py
+++ b/main.py
@@ -59,11 +59,6 @@ async def tour(
         """
     system_prompt = SystemMessagePromptTemplate.from_template(chat_prompt)
 
-    # check if interests has multiple interests
-    if "," in interests:
-        interest_list = interests.split(", ")
-        interests = f"""{", ".join(interest_list[:-1])} and {interest_list[-1]}"""
-
     human_template = f"""
         I am interested in {interests}. I have {duration} hours and would like to walk no more than {distance} miles. My budget is {budget} dollars. I want to start in the {start_time}. Please create a suggested walking tour in {location} based on the previous parameters. I would like the results formatted as valid json with each location having the following fields: location_name, category, story, suggested_visit_duration, and geolocation. The story should be fun and detailed.
         """


### PR DESCRIPTION
## Description

This change looks to update the Human Ask template prompt to be more specific about the formatting of geolocation codes in the API response.

Instead of a mixture of response formats, this looks to consistently return the format as follows:

```JSON
"geolocation": {
  "latitude": 32.7769,
  "longitude": -79.9303
}
```

This change also updates the README to replace some of the remaining default README from the quickstart project, and adds some more updates specific to `wander-api`.

## Testing

Did not test this locally, as I don't have the environment setup for it yet, nor an `OPEN_AI_KEY`.